### PR TITLE
trying my hand at improving on these

### DIFF
--- a/day2/day2.zig
+++ b/day2/day2.zig
@@ -10,43 +10,44 @@ pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
     try stdout.print("AOC 2016 Day 2\n", .{});
 
-    const allocator: *std.mem.Allocator = std.heap.page_allocator;
-    const buf = try std.fs.cwd().readFileAlloc(allocator, "day2/input.1", 4096);
-    defer allocator.free(buf);
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
 
-    var kp = keypads.KeyPad {};
-    var skp = keypads.SuperKeyPad {};
-    try solve(keypads.KeyPad, &kp, buf); // Part 1
-    try solve(keypads.SuperKeyPad, &skp, buf); // Part 2
+    const buf = try std.fs.cwd().readFileAlloc(&gpa.allocator, "day2/input.1", 4096);
+    defer gpa.allocator.free(buf);
+
+    var kp = keypads.KeyPad(
+        \\123
+        \\456
+        \\789
+    , '5'){};
+    var skp = keypads.KeyPad(
+        \\  1  
+        \\ 234 
+        \\56789
+        \\ ABC 
+        \\  D  
+    , '5'){};
+    try solve(&kp, buf); // Part 1
+    try solve(&skp, buf); // Part 2
 }
 
-// ./day2/day2.zig:28:17: error: expected type '*keypads.KeyPad', found '*const keypads.KeyPad'
-// try part1(keypads.KeyPad, kp, buf);
-// fn part1(comptime T: type, kp: T, buf: []const u8) !void {
-fn solve(comptime T: type, kp: *T, buf: []const u8) !void {
+fn solve(kp: anytype, buf: []const u8) !void {
     const stdout = std.io.getStdOut().writer();
-    try stdout.print("{} Code: ", .{ @typeName(T) });
+    try stdout.print("{} Code: ", .{@typeName(@TypeOf(kp).Child)});
 
     for (buf) |val| {
-        switch(val) {
-            'U' => {
-                kp.move(.Up) catch unreachable;
-            },
-            'D' => {
-                kp.move(.Down) catch unreachable;
-            },
-            'L' => {
-                kp.move(.Left) catch unreachable;
-            },
-            'R' => {
-                kp.move(.Right) catch unreachable;
-            },
+        switch (val) {
+            'U' => kp.move(.Up),
+            'D' => kp.move(.Down),
+            'L' => kp.move(.Left),
+            'R' => kp.move(.Right),
             '\n' => {
-                try stdout.print("{X}", .{kp.num});
+                try stdout.print("{c}", .{kp.num});
             },
             else => {
                 return error.BadDirection;
-            }
+            },
         }
     }
     try stdout.print("\n", .{});

--- a/day2/keypads.zig
+++ b/day2/keypads.zig
@@ -1,168 +1,95 @@
 const std = @import("std");
 const assert = std.debug.assert;
 
-pub const KeyPad = struct {
-    num: u8 = 5,
+pub fn KeyPad(comptime map: []const u8, start: u8) type {
+    var rows: []const []const u8 = &[_][]const u8{};
+    var it = std.mem.tokenize(map, "\n");
+    while (it.next()) |row| {
+        rows = rows ++ [_][]const u8{row};
+    }
 
-    pub const Dir = enum {
-        Up,
-        Down,
-        Left,
-        Right
-    };
+    var start_x: u8 = undefined;
+    var start_y: u8 = undefined;
 
-    pub fn move(self: *KeyPad, d: Dir) !void {
-        if((self.num < 1) or (self.num > 9)) {
-            return error.InvalidDigit;
-        }
-
-        switch(d) {
-            .Up => {
-                self.move_up();
-            },
-            .Down => {
-                self.move_down();
-            },
-            .Left => {
-                self.move_left();
-            },
-            .Right => {
-                self.move_right();
+    find_start: {
+        for (rows) |row, y| {
+            for (row) |c, x| {
+                if (c == start) {
+                    start_x = x;
+                    start_y = y;
+                    break :find_start;
+                }
             }
         }
+
+        @compileError("couldn't find start in map");
     }
 
-    fn move_up(self: *KeyPad) void {
-        switch(self.num) {
-            1...3 => {},
-            4...9 => self.num -= 3,
-            else => unreachable
+    return struct {
+        const Self = @This();
+
+        x: u8 = start_x,
+        y: u8 = start_y,
+        num: u8 = rows[start_y][start_x],
+
+        pub const Dir = enum {
+            Up, Down, Left, Right
+        };
+
+        pub fn move(self: *Self, d: Dir) void {
+            switch (d) {
+                .Up => self.move_up(),
+                .Down => self.move_down(),
+                .Left => self.move_left(),
+                .Right => self.move_right(),
+            }
+            self.num = rows[self.y][self.x];
         }
-    }
 
-    fn move_down(self: *KeyPad) void {
-        switch(self.num) {
-            7...9 => {},
-            1...6 => self.num += 3,
-            else => unreachable
+        fn move_up(self: *Self) void {
+            if (self.y == 0 or rows[self.y - 1][self.x] == ' ') return;
+            self.y -= 1;
         }
-    }
 
-    fn move_left(self: *KeyPad) void {
-        switch(self.num) {
-            1, 4, 7 => {},
-            // ./day2/day2.zig:54:49: error: expected token ';', found '}'
-            // 2, 5, 8, 3, 6, 9 => { self.num -= 1 },
-            2, 5, 8, 3, 6, 9 => { self.num -= 1; },
-            else => unreachable
+        fn move_down(self: *Self) void {
+            if (self.y == rows.len - 1 or rows[self.y + 1][self.x] == ' ') return;
+            self.y += 1;
         }
-    }
 
-    fn move_right(self: *KeyPad) void {
-        switch(self.num) {
-            3, 6, 9 => {},
-            1, 4, 7, 2, 5, 8 => { self.num += 1; },
-            else => unreachable
+        fn move_left(self: *Self) void {
+            if (self.x == 0 or rows[self.y][self.x - 1] == ' ') return;
+            self.x -= 1;
         }
-    }
-};
 
-test "keypad" {
-    var kp = KeyPad {};
-
-    assert(kp.num == 5);
-    kp.move(.Up) catch unreachable;
-    assert(kp.num == 2);
-    kp.move(.Up) catch unreachable;
-    assert(kp.num == 2);
-    kp.move(.Left) catch unreachable;
-    assert(kp.num == 1);
-    kp.move(.Left) catch unreachable;
-    assert(kp.num == 1);
-    kp.move(.Right) catch unreachable;
-    assert(kp.num == 2);
-    kp.move(.Right) catch unreachable;
-    assert(kp.num == 3);
-    kp.move(.Right) catch unreachable;
-    assert(kp.num == 3);
-    kp.move(.Down) catch unreachable;
-    assert(kp.num == 6);
-    kp.move(.Down) catch unreachable;
-    assert(kp.num == 9);
-    kp.move(.Down) catch unreachable;
-    assert(kp.num == 9);
+        fn move_right(self: *Self) void {
+            if (self.x == rows[self.y].len - 1 or rows[self.y][self.x + 1] == ' ') return;
+            self.x += 1;
+        }
+    };
 }
 
-// fn move is identical except for bounds check.
-// This begs for a Trait a la Rust. How to do this in Zig?
-pub const SuperKeyPad = struct {
-    num: u8 = 5,
+test "keypad" {
+    var kp = KeyPad("123\n456\n789", '5'){};
 
-    pub const Dir = enum {
-        Up,
-        Down,
-        Left,
-        Right
-    };
-
-    pub fn move(self: *SuperKeyPad, d: Dir) !void {
-        if((self.num < 1) or (self.num > 13)) {
-            return error.InvalidDigit;
-        }
-
-        switch(d) {
-            .Up => {
-                self.move_up();
-            },
-            .Down => {
-                self.move_down();
-            },
-            .Left => {
-                self.move_left();
-            },
-            .Right => {
-                self.move_right();
-            }
-        }
-    }
-
-    fn move_up(self: *SuperKeyPad) void {
-        switch(self.num) {
-            1, 2, 4, 5, 9 => {},
-            3, 13 => { self.num -= 2; },
-            6...8 => self.num -= 4,
-            10...12 => self.num -= 4,
-            else => unreachable
-        }
-    }
-
-    fn move_down(self: *SuperKeyPad) void {
-        switch(self.num) {
-            5, 9, 10, 12, 13 => {},
-            1, 11 => { self.num += 2; },
-            2...4 => self.num += 4,
-            6...8 => self.num += 4,
-            else => unreachable
-        }
-    }
-
-    fn move_left(self: *SuperKeyPad) void {
-        switch(self.num) {
-            1, 2, 5, 10, 13 => {},
-            3...4 => self.num -= 1,
-            6...9 => self.num -= 1,
-            11...12 => self.num -= 1,
-            else => unreachable
-        }
-    }
-
-    fn move_right(self: *SuperKeyPad) void {
-        switch(self.num) {
-            1, 4, 9, 12, 13 => {},
-            2...3 => self.num += 1,
-            5...8 => self.num += 1,
-            10...11 => self.num += 1,
-            else => unreachable
-        }
-    }
-};
+    assert(kp.num == '5');
+    kp.move(.Up);
+    assert(kp.num == '2');
+    kp.move(.Up);
+    assert(kp.num == '2');
+    kp.move(.Left);
+    assert(kp.num == '1');
+    kp.move(.Left);
+    assert(kp.num == '1');
+    kp.move(.Right);
+    assert(kp.num == '2');
+    kp.move(.Right);
+    assert(kp.num == '3');
+    kp.move(.Right);
+    assert(kp.num == '3');
+    kp.move(.Down);
+    assert(kp.num == '6');
+    kp.move(.Down);
+    assert(kp.num == '9');
+    kp.move(.Down);
+    assert(kp.num == '9');
+}

--- a/day3/day3.zig
+++ b/day3/day3.zig
@@ -9,36 +9,38 @@ pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
     try stdout.print("AOC 2016 Day 3\n", .{});
 
-    const allocator: *std.mem.Allocator = std.heap.page_allocator;
-    const buf = try std.fs.cwd().readFileAlloc(allocator, "day3/input.1", 1024*24);
-    defer allocator.free(buf);
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const buf = try std.fs.cwd().readFileAlloc(&gpa.allocator, "day3/input.1", 1024 * 24);
+    defer gpa.allocator.free(buf);
 
     var line_it = mem.tokenize(buf, "\n");
-    var possible_tris : u16 = 0;
+    var possible_tris: u16 = 0;
 
-    while(line_it.next()) |line| {
+    while (line_it.next()) |line| {
         var int_it = mem.tokenize(line, " ");
 
-        var cnt : u8 = 0;
+        var cnt: u8 = 0;
         var sizes: [3]u16 = [3]u16{ 0, 0, 0 };
 
-        while(int_it.next()) |token| {
+        while (int_it.next()) |token| {
             sizes[cnt] = try std.fmt.parseInt(u16, token, 10);
             cnt += 1;
         }
 
-        if(cnt != 3) {
+        if (cnt != 3) {
             return error.TooManyInts;
         }
 
         // const asc_u16 = std.sort.asc(u16);
         // ./day3/day3.zig:35:36: error: unable to evaluate constant expression
-        sort(u16, sizes[0..], {}, asc_u16);
+        sort(u16, &sizes, {}, asc_u16);
 
-        if(sizes[0] + sizes[1] > sizes[2]) {
+        if (sizes[0] + sizes[1] > sizes[2]) {
             possible_tris += 1;
         }
     }
 
-    try stdout.print("Possible Triangles Total: {}\n", .{possible_tris });
+    try stdout.print("Possible Triangles Total: {}\n", .{possible_tris});
 }


### PR DESCRIPTION
There's some noise generated because my text editor automatically runs `zig fmt` on save. Sorry about that :<

I've tried to improve on these by using the current guidelines (e.g. using the new and shiny `std.heap.GeneralPurposeAllocator`, which will tell you about memory leaks! Try removing some frees).

We show off some comptime stuff in day2's `KeyPad`, which I think is really neat! Try changing the parameters to not include the "start" value in the map — it won't compile. It turns out the Zig documentation really wasn't lying when it said:

> ```zig
> // array concatenation works if the values are known
> // at compile time
> ```

I didn't really have anything to improve on day3, so it's mostly `zig fmt`'s changes I think =_=